### PR TITLE
Added function to create TA image and apply flat

### DIFF
--- a/nircam_test.py
+++ b/nircam_test.py
@@ -1,0 +1,30 @@
+#! /usr/bin/env python
+
+"""
+Run the centroiding algorithm on some simulated NIRCam data
+"""
+
+import os
+import glob
+import numpy as np
+import astropy.io.fits as fits
+from jwst_ta import centroid
+
+#files = glob.glob('*.fits')
+#files = ['nrca5_TA_timeseries_NRCFLATA5GRTS_mag09.4_center_15.5_15.5_noiserealiz_1_uncal.fits']
+files = ['nrca5_TA_timeseries_NRCFLATA5GRTS_mag10.0_center_15.5_15.5_noiserealiz_1_uncal.fits']
+#flatfile = 'NRCFLATA5GRTS_flat.fits'
+flatfile = 'NRCFLATA5GRTS_flat_withbadpix.fits'
+
+for file in files[:1]:
+    print(file)
+    with fits.open(file) as h:
+        yd, xd = h[1].data.shape[-2:]
+    xin = 15.
+    yin = 15.
+    # NOTE: The NIRCam checkbox is 3x3 and the fine centroiding box
+    # is 9x9. Making the checkbox larger (e.g. 5x5) leads to very
+    # poor centroiding results.
+    x,y = centroid(infile=file, input_type='ramp', ext=1,
+                   cbox=3, cwin=9, incoord=(xin, yin), bgcorr=-1,
+                   flat=flatfile)


### PR DESCRIPTION
I added a few functions. I haven't had time to test them yet though, so I don't yet call them from the main function. No need to actually merge this yet. I just wanted somewhere for notes on the changes.

Added a function to create a TA image from an exposure. At the moment it only covers the case where three groups are used to create the image. 

I also added a function to apply a flat field and fix bad pixels in the flat. For the flat, I assumed the a file format that matches what is used on board (as explained to me >a year ago). Maybe for this tool, it makes more sense to revert to a more common definition of a flat field (normalized to 1)?

The bad pixel correction function is modeled off of previous work that Paul Goudfrooij did. I'm not sure if this functionality is in the on-board script or not. I thought it might be useful for testing though. In the flat field file, set bad pixels equal to 65535. In the TA image, these pixels are then replaced by the mean or median of surrounding good pixels. 

I'm assuming that the flat field should be applied prior to coarse centroiding. Does it make more sense to do it before or after background subtraction?