### PR TITLE
added the fits file structure check plus few other small fixes

### DIFF
--- a/jwst_ta.py
+++ b/jwst_ta.py
@@ -192,7 +192,7 @@ def centroid(infile=None, input_type='image', ext=0, cbox=5, cwin=5, incoord=(0.
         im = hdu[ext].data
         h = hdu[ext].header
     elif input_type.lower() == 'ramp':
-        im = make_ta_image(infile, ext=ext, useframes=3)
+        im = make_ta_image(infile, ext=ext, useframes=3, save=False)
         # Save TA image for code testing
         h0 = fits.PrimaryHDU(im)
         hl = fits.HDUList([h0])
@@ -262,7 +262,7 @@ def centroid(infile=None, input_type='image', ext=0, cbox=5, cwin=5, incoord=(0.
     yc += yoffset
     print('Coarse centroid found at ({0}, {1})'.format(xc, yc))
 
-    set_trace()
+    #set_trace()
     
     # Iterate fine centroiding
     # Set the threshold to something high (e.g. 1.0) for testing; lower (0.1) for real measurements.
@@ -283,7 +283,7 @@ def centroid(infile=None, input_type='image', ext=0, cbox=5, cwin=5, incoord=(0.
     
 #=====================================================
 
-def make_ta_image(infile, ext=0, useframes=3):
+def make_ta_image(infile, ext=0, useframes=3, save=False):
     """
     Create the image on which to perform the centroiding
     given a fits file containing an exposure with 
@@ -298,7 +298,7 @@ def make_ta_image(infile, ext=0, useframes=3):
               and the integration must have an odd number of groups
     ext -- Extension number containing the data.
            (Change to use 'SCI' rather than number?)
-    useframes -- Number of frames to use for the calculation.
+    useframes -- Number of frames to use for the calculation, provided as an integer or a list of integers.
                  Most of the time 3 frames are used, these 
                  being the 1st, (N+1)/2, and Nth groups
                  of the integration. 
@@ -306,6 +306,8 @@ def make_ta_image(infile, ext=0, useframes=3):
                  There are, apparently, ways to do the calculation
                  with larger numbers of groups, but I haven't 
                  seen the math for those yet.
+                 
+                 When providing a list of integers, the entries must be in the interval [1,NGROUPS]. The code will sort the group                      numbers in ascending order.
 
     Returns:
     --------
@@ -343,17 +345,54 @@ def make_ta_image(infile, ext=0, useframes=3):
         raise RuntimeError(("Warning: Input target acq exposure "
                             "must have an odd number of groups!"))
 
+    # First check whether an integer or a list were provided
     # Group numbers to use. Adjust the values to account for
     # python being 0-indexed
-    if useframes == 3:
-        frames = [0, np.int((ngroups-1)/2), ngroups-1]
+    
+    if type(useframes) is int:
+        if useframes == 3:
+            frames = [0, np.int((ngroups-1)/2), ngroups-1]
+            print('Data has {0} groups'.format(ngroups))
+            print('Using {0} for differencing'.format([frame+1 for frame in frames]))
+            scale = (frames[1] - frames[0]) / (frames[2] - frames[1])
+            #print('Scale = {0}'.format(scale))
+            diff21 = data[frames[1], :, :] - data[frames[0], :, :]
+            diff32 = scale * data[frames[2], :, :] - data[frames[1], :, :]
+            ta_img = np.minimum(diff21, diff32)
+        elif useframes == 5:
+            something_else
+            
+    elif type(useframes) is list:
+        assert all(type(n) is int for n in useframes), "When passing a list to useframes, all entries must be integers."
+        assert len(useframes) in [3, 5], "A useframes list can currently only contain 3 or 5 values."
+        
+        # once asserted we have a list of 3 or 5 integers, sort and check that the numbers make sense.
+        useframes.sort()
+        assert useframes[-1] <= ngroups, "Highest group number exceeds the number of groups in the integration."
+        
+        # adjust the values to account for python being 0-indexed
+        frames = [n-1 for n in useframes]
         print('Data has {0} groups'.format(ngroups))
-        print('Using {0} for differencing'.format(frames))
+        print('Using {0} for differencing'.format([frame+1 for frame in frames]))
+        scale = (frames[1] - frames[0]) / (frames[2] - frames[1])
+        #print('Scale = {0}'.format(scale))
         diff21 = data[frames[1], :, :] - data[frames[0], :, :]
-        diff32 = data[frames[2], :, :] - data[frames[1], :, :]
+        diff32 = scale * data[frames[2], :, :] - data[frames[1], :, :]
         ta_img = np.minimum(diff21, diff32)
-    elif useframes == 5:
-        something_else
+     
+    
+    if save == True:
+        h0 = fits.PrimaryHDU(ta_img)
+        hl = fits.HDUList([h0])
+        indir, inf = os.path.split(infile)
+        # if we've provided a custom list then add the group numbers to the output filename
+        if type(useframes) is list:
+            str_frames = [str(u) for u in useframes]
+            grps = ''.join(str_frames)
+            tafile = os.path.join(indir, 'TA_img_grp'+grps+'_for_'+inf)
+        else:
+            tafile = os.path.join(indir, 'TA_img_for_'+inf)
+        hl.writeto(tafile, overwrite=True)
 
     return ta_img
 

--- a/miri_test.py
+++ b/miri_test.py
@@ -12,8 +12,8 @@ from jwst_ta import centroid, make_ta_image
 # TEST SCRIPT FOR THE TA ALGORITHM
 plt.close('all')
 
-#f = 'MIRI_5489_49_S_20170308-042414_SCE3.fits'
-f = 'TA_img_for_MIRI_5489_49_S_20170308-042414_SCE3.fits'
+f = 'MIRI_5489_55_S_20170308-045954_SCE3.fits'
+#f = 'TA_img_for_MIRI_5489_49_S_20170308-042414_SCE3.fits'
 
 cdir= os.getcwd()
 #os.chdir('../TA_sims/TA_ims/')
@@ -26,14 +26,23 @@ for file in files:
     # these coordinates were obtained with DS9
     xin = 389.440
     yin = 792.498
-    x,y = centroid(infile=file, input_type='image', cbox=5, incoord=(xin, yin), roi=64, bgcorr=-1)
-    #im = make_ta_image(infile=f, ext=0, useframes=3)
+    #x,y = centroid(infile=file, input_type='ramp', cbox=5, incoord=(xin, yin), roi=64, bgcorr=-1)
+    im135 = make_ta_image(infile=f, ext=0, useframes=3, save=True)
+    im234 = make_ta_image(infile=f, ext=0, useframes=[2,3,4], save=True) 
+    #im2 = make_ta_image(infile=f, ext=0, useframes=[1,3,5], save=True)
 #os.chdir(cdir)
+    
+    
+    tafiles = glob.glob('*TA*.fits')
+    for taf in tafiles:
+        print('{0}'.format(taf))
+        x = centroid(infile=taf, input_type='image', cbox=5, incoord=(xin, yin), roi=64, bgcorr=-1)
 
-    #plt.figure(figsize=[8,8])
-    #plt.imshow(im, origin='lower', aspect='equal', cmap='plasma')
-    #plt.colorbar()
-    #plt.show
+
+#    plt.figure(figsize=[8,8])
+#    plt.imshow(im-im2, origin='lower', aspect='equal', cmap='plasma')
+#    plt.colorbar()
+#    plt.show
 
 
 


### PR DESCRIPTION
Main change: added an extra option in make_ta_image for a 3-dimensional file structure. in that case I check against the header keywords that the axis=0 dimension equals NGROUPS * NINT. If that checks out then take just the first integration to produce the TA image, and proceed as normal. If not, raise error.

Minor: in centroid I had to swap x and y where the ROI image is extracted, as x and y were swapped twice. Note I also set the threshold higher for testing purposes, maybe this can be set as a parameter? also convert the extraction pixels to integers explicitly as np.round doesn't return ints (is this a python 3 change? I thought this worked before in python 2). I need to look more closely at this part.