### PR TITLE
updated bgrsub function, fixed coord swap for roi case

### DIFF
--- a/miri_test.py
+++ b/miri_test.py
@@ -5,6 +5,7 @@ import pdb
 import matplotlib.pyplot as plt
 import os
 import glob
+from importlib import reload
 
 
 from jwst_ta import centroid, make_ta_image
@@ -26,7 +27,7 @@ for file in files:
     # these coordinates were obtained with DS9
     xin = 389.313
     yin = 792.000
-    x,y = centroid(infile=file, input_type='ramp', cbox=5, incoord=(xin, yin), roi=64, bgcorr=-1, thresh=0.5)
+    x,y = centroid(infile=file, input_type='ramp', cbox=5, incoord=(xin, yin), roi=64, bgcorr=0.3, thresh=0.5)
     
    
 


### PR DESCRIPTION
Two fixes:
* ensured that the bgrsub() function calculates the value to be subtracted from the pixels in the ROI only, if an ROI was specified. no change for no-background case, for fixed value background subtraction, or for fractional subtraction if no ROI was specified.
* swapped coordinates in centroid() for the ROI case, as the axes were flipped as compared with teh full array case.