### PR TITLE
Useframes fix

### DIFF
--- a/jwst_ta.py
+++ b/jwst_ta.py
@@ -330,7 +330,7 @@ def make_ta_image(infile, ext=0, useframes=3, save=False, silent=False):
         
     shape = data.shape
     
-    pdb.set_trace()
+    #pdb.set_trace()
     if len(shape) <= 2:
         raise RuntimeError(("Warning: Input target acq exposure must "
                             "have multiple groups!"))


### PR DESCRIPTION
This pull request implements one major change and a minor one:
- major: put _brackets_ in the diff32 equation, which applies the scale to the difference rather than the first image only. this was quite a serious bug (bah).
- minor: I included a new keyword "silent" to both make_ta_image() and centroid(). Setting this to True suppresses the screen output.