### PR TITLE
Last frame drop for MIRI TA images

### DIFF
--- a/tests/miri_test.py
+++ b/tests/miri_test.py
@@ -8,12 +8,12 @@ import glob
 from importlib import reload
 
 
-from jwst_ta import centroid, make_ta_image
+from jwst_ta import jwst_ta
 
 # TEST SCRIPT FOR THE TA ALGORITHM
 plt.close('all')
 
-f = 'MIRI_5489_55_S_20170308-045954_SCE3.fits'
+f = 'jw01053001001_02101_00001_mirimage_uncal.fits'
 #f = 'TA_img_for_MIRI_5489_49_S_20170308-042414_SCE3.fits'
 
 cdir= os.getcwd()
@@ -25,9 +25,9 @@ for file in files:
     print(file)
     # h = fits.getheader(file)
     # these coordinates were obtained with DS9
-    xin = 389.313
-    yin = 792.000
-    x,y = centroid(infile=file, input_type='ramp', cbox=5, incoord=(xin, yin), roi=64, bgcorr=0.3, thresh=0.5)
+    xin = 414.
+    yin = 285.
+    x,y = jwst_ta.centroid(infile=file, input_type='ramp', cbox=5, incoord=(xin, yin), roi=48, bgcorr=0.3, thresh=0.5)
     
    
 


### PR DESCRIPTION
modified make_ta_image function to check instrument and drop last group for MIRI. changed default data extension from 0 to 'SCI'