### PR TITLE
Bug fix while applying onboard flat field

### DIFF
--- a/jwst_ta/jwst_ta.py
+++ b/jwst_ta/jwst_ta.py
@@ -551,9 +551,10 @@ def apply_flat_field(image, flat, flattype, silent=False):
     --------
     Flat fielded image -- 2D ndarray
     """
+    # Make sure flat field values are floats
+    flat = flat * 1.
     if flattype=="regular":
-        # Make sure flat field values are floats
-        flat = flat * 1.
+        # Find bad pixels
         print("Found {} bad pixels in the flat.".format(np.sum(np.isnan(flat))))
         # Apply flat
         image /= (flat)


### PR DESCRIPTION
The flat field image of type "onboard" consists of integer values. This caused an Error when trying to replace the bad pixels by NaNs. This PR fixes this bug.